### PR TITLE
Fix: unarchive directory confliction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.1.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.1.0
 	github.com/gen2brain/go-unarr v0.1.1
+	github.com/google/uuid v1.2.0
 	github.com/hashicorp/logutils v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/gen2brain/go-unarr v0.1.1/go.mod h1:P05CsEe8jVEXhxqXqp9mFKUKFV0BKpFmt
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ const (
 	ENV_EVENT     = "CONTAINER_EXEC_EVENT"
 	ENV_LOG_LEVEL = "CONTAINER_EXEC_LOG_LEVEL"
 
-	DEFAULT_CODE_DIR = "/data/lambda"
+	DEFAULT_CODE_DIR = "/tmp/lambda"
 )
 
 type Event interface{}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
 	"github.com/hashicorp/logutils"
 )
 
@@ -80,7 +81,7 @@ func HandleRequest(ctx context.Context, event Event) (Result, error) {
 		codeDir = DEFAULT_CODE_DIR
 	}
 
-	funcDir := filepath.Join(codeDir, key)
+	funcDir := uniquePath(codeDir)
 	if err := os.MkdirAll(funcDir, 0755); err != nil {
 		log.Printf("[DEBUG] failed to create func dir '%s'", funcDir)
 		return nil, err
@@ -253,4 +254,8 @@ func unarchiveTarball(r io.Reader, dest string) error {
 			f.Close()
 		}
 	}
+}
+
+func uniquePath(parent string) string {
+	return filepath.Join(parent, uuid.NewString())
 }


### PR DESCRIPTION
## Problem

```
fatal: destination path '/data/lambda/...' already exists and is not an empty directory.
[WARN] failed to wait command error='exit status 128'END RequestId: 0f5db5a3-b469-4715-811f-883efc16a5a3
```

## Solution

Generate unique directory path to unarchive code every time.